### PR TITLE
Revert allowances for using a Java 20 boot JDK

### DIFF
--- a/make/conf/version-numbers.conf
+++ b/make/conf/version-numbers.conf
@@ -22,9 +22,6 @@
 # or visit www.oracle.com if you need additional information or have any
 # questions.
 #
-# ===========================================================================
-# (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
-# ===========================================================================
 
 # Default version, product, and vendor information to use,
 # unless overridden by configure
@@ -40,6 +37,6 @@ DEFAULT_VERSION_DATE=2024-03-19
 DEFAULT_VERSION_CLASSFILE_MAJOR=66  # "`$EXPR $DEFAULT_VERSION_FEATURE + 44`"
 DEFAULT_VERSION_CLASSFILE_MINOR=0
 DEFAULT_VERSION_DOCS_API_SINCE=11
-DEFAULT_ACCEPTABLE_BOOT_VERSIONS="20 21 22"
+DEFAULT_ACCEPTABLE_BOOT_VERSIONS="21 22"
 DEFAULT_JDK_SOURCE_TARGET_VERSION=22
 DEFAULT_PROMOTED_VERSION_PRE=ea

--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransLiterals.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransLiterals.java
@@ -23,12 +23,6 @@
  * questions.
  */
 
-/*
- * ===========================================================================
- * (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
- * ===========================================================================
- */
-
 package com.sun.tools.javac.comp;
 
 import com.sun.tools.javac.code.Flags;
@@ -260,12 +254,11 @@ public final class TransLiterals extends TreeTranslator {
         }
 
         boolean isNamedProcessor(Name name) {
-            Symbol sym = null;
-            if (processor instanceof JCIdent ident) {
-                sym = ident.sym;
-            } else if (processor instanceof JCFieldAccess access) {
-                sym = access.sym;
-            }
+            Symbol sym = switch (processor) {
+                case JCIdent ident -> ident.sym;
+                case JCFieldAccess access -> access.sym;
+                default -> null;
+            };
             if (sym instanceof VarSymbol varSym) {
                 if (varSym.flags() == (Flags.PUBLIC | Flags.FINAL | Flags.STATIC) &&
                         varSym.name == name &&


### PR DESCRIPTION
This reverts https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/671 and https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/696.
See also https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/730.