### PR TITLE
Add OpenJCEPlus SHA hash to release info file

### DIFF
--- a/closed/custom/ReleaseFile.gmk
+++ b/closed/custom/ReleaseFile.gmk
@@ -1,5 +1,5 @@
 # ===========================================================================
-# (c) Copyright IBM Corp. 2017, 2022 All Rights Reserved
+# (c) Copyright IBM Corp. 2017, 2024 All Rights Reserved
 # ===========================================================================
 # This code is free software; you can redistribute it and/or modify it
 # under the terms of the GNU General Public License version 2 only, as
@@ -21,3 +21,6 @@
 SOURCE_REVISION := OpenJDK:$(shell $(GIT) -C $(TOPDIR) rev-parse --short HEAD)
 SOURCE_REVISION += OpenJ9:$(shell $(GIT) -C $(OPENJ9_TOPDIR) rev-parse --short HEAD)
 SOURCE_REVISION += OMR:$(shell $(GIT) -C $(OPENJ9OMR_TOPDIR) rev-parse --short HEAD)
+ifeq (true,$(BUILD_OPENJCEPLUS))
+  SOURCE_REVISION += OpenJCEPlus:$(shell $(GIT) -C $(OPENJCEPLUS_TOPDIR) rev-parse --short HEAD)
+endif


### PR DESCRIPTION
`OpenJCEPlus`'s hash info is added to the `release` file, which is contained within the jdk, if `OpenJCEPlus` is bundled.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/738

Signed-off by: Kostas Tsiounis [kostas.tsiounis@ibm.com](mailto:kostas.tsiounis@ibm.com)