### PR TITLE
8325254: CKA_TOKEN private and secret keys are not necessarily sensitive

### DIFF
--- a/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
+++ b/src/jdk.crypto.cryptoki/share/classes/sun/security/pkcs11/P11Key.java
@@ -437,8 +437,9 @@ abstract class P11Key implements Key, Length {
                     new CK_ATTRIBUTE(CKA_EXTRACTABLE),
         });
 
-        boolean keySensitive = (attrs[0].getBoolean() ||
-                attrs[1].getBoolean() || !attrs[2].getBoolean());
+        boolean keySensitive =
+                (attrs[0].getBoolean() && P11Util.isNSS(session.token)) ||
+                attrs[1].getBoolean() || !attrs[2].getBoolean();
 
         if (keySensitive && (SunPKCS11.mysunpkcs11 != null) && "RSA".equals(algorithm)) {
             try {


### PR DESCRIPTION
Cherry pick https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/992eee8aeaa8 for jdk22.

OpenJDK has backported this change to https://github.com/ibmruntimes/openj9-openjdk-jdk21/commit/fc9b75d63279 but doesn't backport to feature releases (i.e. jdk22). 

This change is important to Z platforms. 
FYI @BobMDu