### PR TITLE
Set property com.ibm.fips.mode based upon active profile

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -472,6 +472,12 @@ public final class RestrictedSecurity {
         propsMapping.put("jdk.tls.legacyAlgorithms", restricts.jdkTlsLegacyAlgorithms);
         propsMapping.put("jdk.certpath.disabledAlgorithms", restricts.jdkCertpathDisabledAlgorithms);
         propsMapping.put("jdk.security.legacyAlgorithm", restricts.jdkSecurityLegacyAlgorithm);
+        String fipsMode = System.getProperty("com.ibm.fips.mode");
+        if (fipsMode == null) {
+            System.setProperty("com.ibm.fips.mode", restricts.jdkFipsMode);
+        } else if (!fipsMode.equals(restricts.jdkFipsMode)) {
+            printStackTraceAndExit("Property com.ibm.fips.mode is incompatible with semeru.customprofile and semeru.fips properties");
+        }
 
         for (Map.Entry<String, String> entry : propsMapping.entrySet()) {
             String jdkPropsName = entry.getKey();
@@ -592,6 +598,8 @@ public final class RestrictedSecurity {
         // For SecureRandom.
         String jdkSecureRandomProvider;
         String jdkSecureRandomAlgorithm;
+
+        String jdkFipsMode;
 
         // Provider with argument (provider name + optional argument).
         private final List<String> providers;
@@ -749,6 +757,8 @@ public final class RestrictedSecurity {
                     securityProps.getProperty(profileID + ".securerandom.provider"));
             jdkSecureRandomAlgorithm = parseProperty(
                     securityProps.getProperty(profileID + ".securerandom.algorithm"));
+            jdkFipsMode = parseProperty(
+                    securityProps.getProperty(profileID + ".fips.mode"));
 
             if (debug != null) {
                 debug.println("\tProperties of restricted security profile successfully loaded.");
@@ -1068,6 +1078,8 @@ public final class RestrictedSecurity {
                     securityProps.getProperty(profileToPrint + ".desc.default"));
             printProperty(profileToPrint + ".desc.fips: ",
                     securityProps.getProperty(profileToPrint + ".desc.fips"));
+            printProperty(profileToPrint + ".fips.mode: ",
+                    securityProps.getProperty(profileToPrint + ".fips.mode"));
             printProperty(profileToPrint + ".desc.number: ",
                     parseProperty(securityProps.getProperty(profileToPrint + ".desc.number")));
             printProperty(profileToPrint + ".desc.policy: ",

--- a/src/java.base/share/conf/security/java.security
+++ b/src/java.base/share/conf/security/java.security
@@ -97,6 +97,7 @@ RestrictedSecurity.NSS.140-2.desc.fips = true
 RestrictedSecurity.NSS.140-2.desc.number = Certificate #4413
 RestrictedSecurity.NSS.140-2.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/4413
 RestrictedSecurity.NSS.140-2.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.NSS.140-2.fips.mode = 140-2
 
 RestrictedSecurity.NSS.140-2.tls.disabledNamedCurves =
 RestrictedSecurity.NSS.140-2.tls.disabledAlgorithms = \
@@ -162,6 +163,8 @@ RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.fips = true
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.number = Certificate #XXX
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.policy = https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.desc.sunsetDate = 2026-09-21
+RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.fips.mode = 140-3
+
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.disabledNamedCurves =
 RestrictedSecurity.OpenJCEPlusFIPS.FIPS140-3.tls.disabledAlgorithms = \
     3DES_EDE_CBC, \


### PR DESCRIPTION
When loading a restricted security mode profile we need to set the property value `com.ibm.fips.mode` to the value contained within the active profile.

Signed-off-by: Jason Katonica <katonica@us.ibm.com>