### PR TITLE
(0.45) Remove the unneeded Hotspot features for building OpenJ9

### DIFF
--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -675,9 +675,6 @@ AC_DEFUN_ONCE([CUSTOM_LATE_HOOK],
   # Create the custom-spec.gmk
   AC_CONFIG_FILES([$OUTPUTDIR/custom-spec.gmk:$CLOSED_AUTOCONF_DIR/custom-spec.gmk.in])
 
-  # explicitly disable CDS archive generation (OpenJ9 does not support '-Xshare:dump')
-  BUILD_CDS_ARCHIVE=false
-
   # Override the default for '--with-output-sync' to 'none' for better feedback during VM build.
   if test "x[$with_output_sync]" = x ; then
     OUTPUT_SYNC_SUPPORTED=false

--- a/closed/autoconf/custom-hook.m4
+++ b/closed/autoconf/custom-hook.m4
@@ -680,9 +680,6 @@ AC_DEFUN_ONCE([CUSTOM_LATE_HOOK],
     OUTPUT_SYNC_SUPPORTED=false
   fi
 
-  # explicitly disable classlist generation
-  ENABLE_GENERATE_CLASSLIST=false
-
   if test "x$OPENJDK_BUILD_OS" = xwindows ; then
     OPENJ9_TOOL_DIR="$OUTPUTDIR/tools"
     AC_SUBST(OPENJ9_TOOL_DIR)

--- a/closed/autoconf/custom-spec.gmk.in
+++ b/closed/autoconf/custom-spec.gmk.in
@@ -183,9 +183,6 @@ $(foreach var, \
 J9JCL_SOURCES_DIR      := $(SUPPORT_OUTPUTDIR)/j9jcl
 J9JCL_SOURCES_DONEFILE := $(MAKESUPPORT_OUTPUTDIR)/j9jcl.done
 
-# Disable all hotspot features.
-JVM_FEATURES_server :=
-
 # Required by OpenJCEPlus.
 BUILD_OPENJCEPLUS  := @BUILD_OPENJCEPLUS@
 OPENJCEPLUS_TOPDIR := $(TOPDIR)/OpenJCEPlus

--- a/make/autoconf/jvm-features.m4
+++ b/make/autoconf/jvm-features.m4
@@ -23,7 +23,7 @@
 # questions.
 #
 # ===========================================================================
-# (c) Copyright IBM Corp. 2023, 2023 All Rights Reserved
+# (c) Copyright IBM Corp. 2023, 2024 All Rights Reserved
 # ===========================================================================
 
 ###############################################################################
@@ -47,9 +47,8 @@
 m4_define(jvm_features_valid, m4_normalize( \
     ifdef([custom_jvm_features_valid], custom_jvm_features_valid) \
     \
-    cds compiler1 compiler2 dtrace epsilongc g1gc jfr jni-check \
-    jvmci jvmti link-time-opt management minimal opt-size parallelgc \
-    serialgc services shenandoahgc static-build vm-structs zero zgc \
+    dtrace jfr \
+    link-time-opt management opt-size \
 ))
 
 # Deprecated JVM features (these are ignored, but with a warning)
@@ -235,7 +234,10 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_CDS],
 [
   JVM_FEATURES_CHECK_AVAILABILITY(cds, [
     AC_MSG_CHECKING([if platform is supported by CDS])
-    if test "x$OPENJDK_TARGET_OS" = xaix; then
+    if true; then
+      AC_MSG_RESULT([no, OpenJ9])
+      AVAILABLE=false
+    elif test "x$OPENJDK_TARGET_OS" = xaix; then
       AC_MSG_RESULT([no, $OPENJDK_TARGET_OS-$OPENJDK_TARGET_CPU])
       AVAILABLE=false
     else
@@ -303,7 +305,10 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_SHENANDOAHGC],
 [
   JVM_FEATURES_CHECK_AVAILABILITY(shenandoahgc, [
     AC_MSG_CHECKING([if platform is supported by Shenandoah])
-    if test "x$OPENJDK_TARGET_CPU_ARCH" = "xx86" || \
+    if true; then
+      AC_MSG_RESULT([no, OpenJ9])
+      AVAILABLE=false
+    elif test "x$OPENJDK_TARGET_CPU_ARCH" = "xx86" || \
         test "x$OPENJDK_TARGET_CPU" = "xaarch64" || \
         test "x$OPENJDK_TARGET_CPU" = "xppc64le" || \
         test "x$OPENJDK_TARGET_CPU" = "xriscv64"; then
@@ -338,7 +343,10 @@ AC_DEFUN_ONCE([JVM_FEATURES_CHECK_ZGC],
 [
   JVM_FEATURES_CHECK_AVAILABILITY(zgc, [
     AC_MSG_CHECKING([if platform is supported by ZGC])
-    if test "x$OPENJDK_TARGET_CPU" = "xx86_64"; then
+    if true; then
+      AC_MSG_RESULT([no, OpenJ9])
+      AVAILABLE=false
+    elif test "x$OPENJDK_TARGET_CPU" = "xx86_64"; then
       if test "x$OPENJDK_TARGET_OS" = "xlinux" || \
           test "x$OPENJDK_TARGET_OS" = "xwindows" || \
           test "x$OPENJDK_TARGET_OS" = "xmacosx"; then
@@ -540,13 +548,6 @@ AC_DEFUN([JVM_FEATURES_VERIFY],
   fi
   if JVM_FEATURES_IS_ACTIVE(compiler2); then
     INCLUDE_COMPILER2="true"
-  fi
-
-  # Verify that we have at least one gc selected (i.e., feature named "*gc").
-  if ! JVM_FEATURES_IS_ACTIVE(.*gc); then
-      AC_MSG_NOTICE([At least one gc needed for variant '$variant'.])
-      AC_MSG_NOTICE([Specified features: '$JVM_FEATURES_ACTIVE'])
-      AC_MSG_ERROR([Cannot continue])
   fi
 ])
 


### PR DESCRIPTION
OpenJ9 builds don't need to include support for the removed Hotspot features:
`cds compiler1 compiler2 jni-check jvmci jvmti minimal services static-build vm-structs zero`
and all the gc's.

In particular this removes libsimdsort.so on xlinux, which is unused.

With this change configure shows:
`checking JVM features to use for variant 'server'... 'dtrace jfr management'`

Port of https://github.com/ibmruntimes/openj9-openjdk-jdk22/pull/45 and https://github.com/ibmruntimes/openj9-openjdk-jdk22/pull/47 to 0.45