### PR TITLE
Get rid of AIX linker option: -bnorwexec

### DIFF
--- a/make/autoconf/flags-ldflags.m4
+++ b/make/autoconf/flags-ldflags.m4
@@ -27,7 +27,7 @@
 #
 
 # ===========================================================================
-# (c) Copyright IBM Corp. 2019, 2019 All Rights Reserved
+# (c) Copyright IBM Corp. 2019, 2024 All Rights Reserved
 # ===========================================================================
 
 AC_DEFUN([FLAGS_SETUP_LDFLAGS],
@@ -86,7 +86,7 @@ AC_DEFUN([FLAGS_SETUP_LDFLAGS_HELPER],
     LDFLAGS_CXX_PARTIAL_LINKING="$MACHINE_FLAG -r"
 
     if test "x$OPENJDK_TARGET_OS" = xaix; then
-      BASIC_LDFLAGS="-Wl,-b64 -Wl,-brtl -Wl,-bnorwexec -Wl,-bnolibpath -Wl,-bnoexpall \
+      BASIC_LDFLAGS="-Wl,-b64 -Wl,-brtl -Wl,-bnolibpath -Wl,-bnoexpall \
         -Wl,-bernotok -Wl,-bdatapsize:64k -Wl,-btextpsize:64k -Wl,-bstackpsize:64k"
       BASIC_LDFLAGS_JVM_ONLY="$BASIC_LDFLAGS_JVM_ONLY -Wl,-lC_r -Wl,-bbigtoc"
     fi


### PR DESCRIPTION
High-level: this linker option is oxymoronic with JIT environment (where executable code are generated on the fly anyway).

At least for the time being before we figured out why default codeCache is allocated through malloc (instead of mmap or shmget, for which that linker option appeared to have no effect by my tests).

Even after we figured it out eventually, it is a legitimate question what value this option provides for JIT environment.

this also has effect on FFI thunks (which are not generated in JIT codecache).

Issue https://github.com/ibmruntimes/openj9-openjdk-jdk21/issues/162