### PR TITLE
Postpone hash check of security profiles

### DIFF
--- a/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
+++ b/closed/src/java.base/share/classes/openj9/internal/security/RestrictedSecurity.java
@@ -76,6 +76,8 @@ public final class RestrictedSecurity {
 
     private static String userSecurityID;
 
+    private static ProfileParser profileParser;
+
     private static RestrictedSecurityProperties restricts;
 
     private static final Set<String> unmodifiableProperties = new HashSet<>();
@@ -167,6 +169,20 @@ public final class RestrictedSecurity {
 
     private RestrictedSecurity() {
         super();
+    }
+
+    /**
+     * Check loaded profiles' hash values.
+     *
+     * In order to avoid unintentional changes in profiles and incentivize
+     * extending profiles, instead of altering them, a digest of the profile
+     * is calculated and compared to the expected value.
+     */
+    public static void checkHashValues() {
+        if (profileParser != null) {
+            profileParser.checkHashValues();
+            profileParser = null;
+        }
     }
 
     /**
@@ -447,7 +463,7 @@ public final class RestrictedSecurity {
                 checkIfKnownProfileSupported();
 
                 // Initialize restricted security properties from java.security file.
-                ProfileParser profileParser = new ProfileParser(profileID, props);
+                profileParser = new ProfileParser(profileID, props);
                 restricts = profileParser.getProperties();
 
                 // Restricted security properties checks.
@@ -477,9 +493,6 @@ public final class RestrictedSecurity {
                 }
 
                 securityEnabled = true;
-
-                // Check whether the hash values match (i.e., profiles haven't been altered).
-                profileParser.checkHashValues();
             }
         } catch (Exception e) {
             if (debug != null) {

--- a/src/java.base/share/classes/sun/security/jca/Providers.java
+++ b/src/java.base/share/classes/sun/security/jca/Providers.java
@@ -23,9 +23,17 @@
  * questions.
  */
 
+/*
+ * ===========================================================================
+ * (c) Copyright IBM Corp. 2024, 2024 All Rights Reserved
+ * ===========================================================================
+ */
+
 package sun.security.jca;
 
 import java.security.Provider;
+
+import openj9.internal.security.RestrictedSecurity;
 import sun.security.x509.AlgorithmId;
 
 /**
@@ -53,6 +61,7 @@ public class Providers {
         // triggers a getInstance() call (although that should not happen)
         providerList = ProviderList.EMPTY;
         providerList = ProviderList.fromSecurityProperties();
+        RestrictedSecurity.checkHashValues();
     }
 
     private Providers() {


### PR DESCRIPTION
The check for the hash value of loaded security profiles is postponed until the provider list has been populated.

Back-ported from: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/807

Signed-off-by: Kostas Tsiounis <kostas.tsiounis@ibm.com>